### PR TITLE
[dynamodb] sync-up with openhab1-addons repo and bnd dependencies

### DIFF
--- a/bundles/org.openhab.persistence.dynamodb/README.md
+++ b/bundles/org.openhab.persistence.dynamodb/README.md
@@ -55,21 +55,21 @@ This service can be configured in the file `services/dynamodb.cfg`.
 
 ### Basic configuration
 
-| Property | Default | Required | Description |
-|----------|---------|:--------:|-------------|
-| accessKey |        |    Yes   | access key as shown in [Setting up Amazon account](#setting-up-amazon-account). |
-| secretKey |        |    Yes   | secret key as shown in [Setting up Amazon account](#setting-up-amazon-account). |
-| region   |         |    Yes   | AWS region ID as described in [Setting up Amazon account](#setting-up-amazon-account). The region needs to match the region that was used to create the user. |
+| Property  | Default | Required | Description                                                                                                                                                   |
+| --------- | ------- | :------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| accessKey |         |   Yes    | access key as shown in [Setting up Amazon account](#setting-up-amazon-account).                                                                               |
+| secretKey |         |   Yes    | secret key as shown in [Setting up Amazon account](#setting-up-amazon-account).                                                                               |
+| region    |         |   Yes    | AWS region ID as described in [Setting up Amazon account](#setting-up-amazon-account). The region needs to match the region that was used to create the user. |
 
 ### Configuration Using Credentials File
 
 Alternatively, instead of specifying `accessKey` and `secretKey`, one can configure a configuration profile file.
 
-| Property | Default | Required | Description |
-|----------|---------|:--------:|-------------|
-| profilesConfigFile | |  Yes   | path to the credentials file.  For example, `/etc/openhab2/aws_creds`. Please note that the user that runs openHAB must have approriate read rights to the credential file. For more details on the Amazon credential file format, see [Amazon documentation](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html). |
-| profile  |         |    Yes   | name of the profile to use |
-| region   |         |    Yes   | AWS region ID as described in Step 2 in [Setting up Amazon account](#setting-up-amazon-account). The region needs to match the region that was used to create the user. |
+| Property           | Default | Required | Description                                                                                                                                                                                                                                                                                                                                    |
+| ------------------ | ------- | :------: | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| profilesConfigFile |         |   Yes    | path to the credentials file.  For example, `/etc/openhab2/aws_creds`. Please note that the user that runs openHAB must have approriate read rights to the credential file. For more details on the Amazon credential file format, see [Amazon documentation](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html). |
+| profile            |         |   Yes    | name of the profile to use                                                                                                                                                                                                                                                                                                                     |
+| region             |         |   Yes    | AWS region ID as described in Step 2 in [Setting up Amazon account](#setting-up-amazon-account). The region needs to match the region that was used to create the user.                                                                                                                                                                        |
 
 Example of service configuration file (`services/dynamodb.cfg`):
 
@@ -91,11 +91,15 @@ aws_secret_access_key=testSecretKey
 
 In addition to the configuration properties above, the following are also available:
 
-| Property | Default | Required | Description |
-|----------|---------|:--------:|-------------|
-| readCapacityUnits | 1 |  No   | read capacity for the created tables |
-| writeCapacityUnits | 1 | No   | write capacity for the created tables |
-| tablePrefix | `openhab-` | No | table prefix used in the name of created tables |
+| Property                   | Default    | Required | Description                                                                                        |
+| -------------------------- | ---------- | :------: | -------------------------------------------------------------------------------------------------- |
+| readCapacityUnits          | 1          |    No    | read capacity for the created tables                                                               |
+| writeCapacityUnits         | 1          |    No    | write capacity for the created tables                                                              |
+| tablePrefix                | `openhab-` |    No    | table prefix used in the name of created tables                                                    |
+| bufferCommitIntervalMillis | 1000       |    No    | Interval to commit (write) buffered data. In milliseconds.                                         |
+| bufferSize                 | 1000       |    No    | Internal buffer size which is used to batch writes to DynamoDB every `bufferCommitIntervalMillis`. |
+
+Typically you should not need to modify parameters related to buffering. 
 
 Refer to Amazon documentation on [provisioned throughput](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ProvisionedThroughput.html) for details on read/write capacity.
 
@@ -105,9 +109,19 @@ All item- and event-related configuration is done in the file `persistence/dynam
 
 ### Tables Creation
 
-When an item is persisted via this service, a table is created (if necessary). Currently, the service will create at most two tables for different item types. The tables will be named `<prefix><item-type>`, where `<prefix>` matches the `tablePrefix` configuration property; while the `<item-type>` is either `bigdecimal` (numeric items) or `string` (string and complex items).
+When an item is persisted via this service, a table is created (if necessary). Currently, the service will create at most two tables for different item types. The tables will be named `<tablePrefix><item-type>`, where the `<item-type>` is either `bigdecimal` (numeric items) or `string` (string and complex items).
 
 Each table will have three columns: `itemname` (item name), `timeutc` (in ISO 8601 format with millisecond accuracy), and `itemstate` (either a number or string representing item state).
+
+## Buffering
+
+By default, the service is asynchronous which means that data is not written immediately to DynamoDB but instead buffered in-memory.
+The size of the buffer, in terms of datapoints, can be configured with `bufferSize`.
+Every `bufferCommitIntervalMillis` the whole buffer of data is flushed to DynamoDB.
+
+It is recommended to have the buffering enabled since the synchronous behaviour (writing data immediately) might have adverse impact to the whole system when there is many items persisted at the same time. The buffering can be disabled by setting `bufferSize` to zero.
+
+The defaults should be suitable in many use cases.
 
 ### Caveats
 
@@ -129,3 +143,19 @@ When the tables are created, the read/write capacity is configured according to 
 `ls lib/*.jar | python -c "import sys;pre='<classpathentry exported=\"true\" kind=\"lib\" path=\"';post='\"/>'; print('\\t' + pre + (post + '\\n\\t' + pre).join(map(str.strip, sys.stdin.readlines())) + post)"`
 
 After these changes, it's good practice to run integration tests (against live AWS DynamoDB) in `org.openhab.persistence.dynamodb.test` bundle. See README.md in the test bundle for more information how to execute the tests.
+
+### Running integration tests
+
+To run integration tests, one needs to provide AWS credentials.
+
+Eclipse instructions
+1. Run all tests (in package org.openhab.persistence.dynamodb.internal) as JUnit Tests
+2. Configure the run configuration, and open Arguments sheet
+3. In VM arguments, provide the credentials for AWS
+````
+-DDYNAMODBTEST_REGION=REGION-ID
+-DDYNAMODBTEST_ACCESS=ACCESS-KEY
+-DDYNAMODBTEST_SECRET=SECRET
+````
+
+The tests will create tables with prefix `dynamodb-integration-tests-`. Note that when tests are begun, all data is removed from that table!

--- a/bundles/org.openhab.persistence.dynamodb/pom.xml
+++ b/bundles/org.openhab.persistence.dynamodb/pom.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
-  <modelVersion>4.0.0</modelVersion>
+	<modelVersion>4.0.0</modelVersion>
 
-  <parent>
-    <groupId>org.openhab.addons.bundles</groupId>
-    <artifactId>org.openhab.addons.reactor.bundles</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
-  </parent>
+	<parent>
+		<groupId>org.openhab.addons.bundles</groupId>
+		<artifactId>org.openhab.addons.reactor.bundles</artifactId>
+		<version>2.5.0-SNAPSHOT</version>
+	</parent>
 
-  <artifactId>org.openhab.persistence.dynamodb</artifactId>
+	<artifactId>org.openhab.persistence.dynamodb</artifactId>
 
-  <name>openHAB Add-ons :: Bundles :: DynamoDB Persistence</name>
+	<name>openHAB Add-ons :: Bundles :: DynamoDB Persistence</name>
 
 	<dependencies>
 			<dependency>

--- a/bundles/org.openhab.persistence.dynamodb/pom.xml
+++ b/bundles/org.openhab.persistence.dynamodb/pom.xml
@@ -13,4 +13,11 @@
 
   <name>openHAB Add-ons :: Bundles :: DynamoDB Persistence</name>
 
+	<dependencies>
+			<dependency>
+				<groupId>com.amazonaws</groupId>
+				<artifactId>aws-java-sdk-dynamodb</artifactId>
+				<version>1.11.213</version>
+			</dependency>
+	</dependencies>
 </project>

--- a/bundles/org.openhab.persistence.dynamodb/src/main/java/org/openhab/persistence/dynamodb/internal/AbstractBufferedPersistenceService.java
+++ b/bundles/org.openhab.persistence.dynamodb/src/main/java/org/openhab/persistence/dynamodb/internal/AbstractBufferedPersistenceService.java
@@ -1,0 +1,103 @@
+package org.openhab.persistence.dynamodb.internal;
+
+import java.util.Date;
+import java.util.UUID;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import org.openhab.core.items.Item;
+import org.openhab.core.persistence.PersistenceService;
+import org.openhab.core.types.State;
+import org.openhab.core.types.UnDefType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class AbstractBufferedPersistenceService<T> implements PersistenceService {
+
+    private static final long BUFFER_OFFER_TIMEOUT_MILLIS = 500;
+
+    private final Logger logger = LoggerFactory.getLogger(AbstractBufferedPersistenceService.class);
+    protected BlockingQueue<T> buffer;
+
+    private boolean writeImmediately;
+
+    protected void resetWithBufferSize(int bufferSize) {
+        int capacity = Math.max(1, bufferSize);
+        buffer = new ArrayBlockingQueue<T>(capacity, true);
+        writeImmediately = bufferSize == 0;
+    }
+
+    protected abstract T persistenceItemFromState(String name, State state, Date time);
+
+    protected abstract boolean isReadyToStore();
+
+    protected abstract void flushBufferedData();
+
+    @Override
+    public void store(Item item) {
+        store(item, null);
+    }
+
+    @Override
+    public void store(Item item, String alias) {
+        long storeStart = System.currentTimeMillis();
+        String uuid = UUID.randomUUID().toString();
+        if (item.getState() instanceof UnDefType) {
+            logger.debug("Undefined item state received. Not storing item {}.", item.getName());
+            return;
+        }
+        if (!isReadyToStore()) {
+            return;
+        }
+        if (buffer == null) {
+            throw new IllegalStateException("Buffer not initialized with resetWithBufferSize. Bug?");
+        }
+        Date time = new Date(storeStart);
+        String realName = item.getName();
+        String name = (alias != null) ? alias : realName;
+        State state = item.getState();
+        T persistenceItem = persistenceItemFromState(name, state, time);
+        logger.trace("store() called with item {}, which was converted to {} [{}]", item, persistenceItem, uuid);
+        if (writeImmediately) {
+            logger.debug("Writing immediately item {} [{}]", realName, uuid);
+            // We want to write everything immediately
+            // Synchronous behaviour to ensure buffer does not get full.
+            synchronized (this) {
+                boolean buffered = addToBuffer(persistenceItem);
+                assert buffered;
+                flushBufferedData();
+            }
+        } else {
+            long bufferStart = System.currentTimeMillis();
+            boolean buffered = addToBuffer(persistenceItem);
+            if (buffered) {
+                logger.debug("Buffered item {} in {} ms. Total time for store(): {} [{}]", realName,
+                        System.currentTimeMillis() - bufferStart, System.currentTimeMillis() - storeStart, uuid);
+            } else {
+                logger.debug(
+                        "Buffer is full. Writing buffered data immediately and trying again. Consider increasing bufferSize");
+                // Buffer is full, commit it immediately
+                flushBufferedData();
+                boolean buffered2 = addToBuffer(persistenceItem);
+                if (buffered2) {
+                    logger.debug("Buffered item in {} ms (2nd try, flushed buffer in-between) [{}]",
+                            System.currentTimeMillis() - bufferStart, uuid);
+                } else {
+                    // The unlikely case happened -- buffer got full again immediately
+                    logger.warn("Buffering failed for the second time -- Too small bufferSize? Discarding data [{}]",
+                            uuid);
+                }
+            }
+        }
+    }
+
+    protected boolean addToBuffer(T persistenceItem) {
+        try {
+            return buffer.offer(persistenceItem, BUFFER_OFFER_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            logger.warn("Interrupted when trying to buffer data! Dropping data");
+            return false;
+        }
+    }
+}

--- a/bundles/org.openhab.persistence.dynamodb/src/main/java/org/openhab/persistence/dynamodb/internal/DynamoDBConfig.java
+++ b/bundles/org.openhab.persistence.dynamodb/src/main/java/org/openhab/persistence/dynamodb/internal/DynamoDBConfig.java
@@ -31,6 +31,8 @@ public class DynamoDBConfig {
     public static final boolean DEFAULT_CREATE_TABLE_ON_DEMAND = true;
     public static final long DEFAULT_READ_CAPACITY_UNITS = 1;
     public static final long DEFAULT_WRITE_CAPACITY_UNITS = 1;
+    public static final long DEFAULT_BUFFER_COMMIT_INTERVAL_MILLIS = 1000;
+    public static final int DEFAULT_BUFFER_SIZE = 1000;
 
     private static final Logger logger = LoggerFactory.getLogger(DynamoDBConfig.class);
 
@@ -40,6 +42,8 @@ public class DynamoDBConfig {
     private boolean createTable = DEFAULT_CREATE_TABLE_ON_DEMAND;
     private long readCapacityUnits = DEFAULT_READ_CAPACITY_UNITS;
     private long writeCapacityUnits = DEFAULT_WRITE_CAPACITY_UNITS;
+    private long bufferCommitIntervalMillis = DEFAULT_BUFFER_COMMIT_INTERVAL_MILLIS;
+    private int bufferSize = DEFAULT_BUFFER_SIZE;
 
     /**
      *
@@ -117,7 +121,26 @@ public class DynamoDBConfig {
                 writeCapacityUnits = Long.parseLong(writeCapacityUnitsParam);
             }
 
-            return new DynamoDBConfig(region, credentials, table, createTable, readCapacityUnits, writeCapacityUnits);
+            final long bufferCommitIntervalMillis;
+            String bufferCommitIntervalMillisParam = (String) config.get("bufferCommitIntervalMillis");
+            if (isBlank(bufferCommitIntervalMillisParam)) {
+                logger.debug("Buffer commit interval millis: {}", DEFAULT_BUFFER_COMMIT_INTERVAL_MILLIS);
+                bufferCommitIntervalMillis = DEFAULT_BUFFER_COMMIT_INTERVAL_MILLIS;
+            } else {
+                bufferCommitIntervalMillis = Long.parseLong(bufferCommitIntervalMillisParam);
+            }
+
+            final int bufferSize;
+            String bufferSizeParam = (String) config.get("bufferSize");
+            if (isBlank(bufferSizeParam)) {
+                logger.debug("Buffer size: {}", DEFAULT_BUFFER_SIZE);
+                bufferSize = DEFAULT_BUFFER_SIZE;
+            } else {
+                bufferSize = Integer.parseInt(bufferSizeParam);
+            }
+
+            return new DynamoDBConfig(region, credentials, table, createTable, readCapacityUnits, writeCapacityUnits,
+                    bufferCommitIntervalMillis, bufferSize);
         } catch (Exception e) {
             logger.error("Error with configuration", e);
             return null;
@@ -125,13 +148,15 @@ public class DynamoDBConfig {
     }
 
     public DynamoDBConfig(Regions region, AWSCredentials credentials, String table, boolean createTable,
-            long readCapacityUnits, long writeCapacityUnits) {
+            long readCapacityUnits, long writeCapacityUnits, long bufferCommitIntervalMillis, int bufferSize) {
         this.region = region;
         this.credentials = credentials;
         this.tablePrefix = table;
         this.createTable = createTable;
         this.readCapacityUnits = readCapacityUnits;
         this.writeCapacityUnits = writeCapacityUnits;
+        this.bufferCommitIntervalMillis = bufferCommitIntervalMillis;
+        this.bufferSize = bufferSize;
     }
 
     public AWSCredentials getCredentials() {
@@ -156,6 +181,14 @@ public class DynamoDBConfig {
 
     public long getWriteCapacityUnits() {
         return writeCapacityUnits;
+    }
+
+    public long getBufferCommitIntervalMillis() {
+        return bufferCommitIntervalMillis;
+    }
+
+    public int getBufferSize() {
+        return bufferSize;
     }
 
     private static void invalidRegionLogHelp(String region) {

--- a/bundles/org.openhab.persistence.dynamodb/src/main/java/org/openhab/persistence/dynamodb/internal/DynamoDBQueryUtils.java
+++ b/bundles/org.openhab.persistence.dynamodb/src/main/java/org/openhab/persistence/dynamodb/internal/DynamoDBQueryUtils.java
@@ -1,0 +1,129 @@
+package org.openhab.persistence.dynamodb.internal;
+
+import java.util.Collections;
+import java.util.Date;
+
+import org.openhab.core.persistence.FilterCriteria;
+import org.openhab.core.persistence.FilterCriteria.Operator;
+import org.openhab.core.persistence.FilterCriteria.Ordering;
+
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBQueryExpression;
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.amazonaws.services.dynamodbv2.model.ComparisonOperator;
+import com.amazonaws.services.dynamodbv2.model.Condition;
+
+public class DynamoDBQueryUtils {
+    /**
+     * Construct dynamodb query from filter
+     *
+     * @param filter
+     * @return DynamoDBQueryExpression corresponding to the given FilterCriteria
+     */
+    public static DynamoDBQueryExpression<DynamoDBItem<?>> createQueryExpression(
+            Class<? extends DynamoDBItem<?>> dtoClass, FilterCriteria filter) {
+        DynamoDBItem<?> item = getDynamoDBHashKey(dtoClass, filter.getItemName());
+        final DynamoDBQueryExpression<DynamoDBItem<?>> queryExpression = new DynamoDBQueryExpression<DynamoDBItem<?>>()
+                .withHashKeyValues(item).withScanIndexForward(filter.getOrdering() == Ordering.ASCENDING)
+                .withLimit(filter.getPageSize());
+        maybeAddTimeFilter(queryExpression, filter);
+        maybeAddStateFilter(filter, queryExpression);
+        return queryExpression;
+    }
+
+    private static DynamoDBItem<?> getDynamoDBHashKey(Class<? extends DynamoDBItem<?>> dtoClass, String itemName) {
+        DynamoDBItem<?> item;
+        try {
+            item = dtoClass.newInstance();
+        } catch (InstantiationException e) {
+            throw new RuntimeException(e);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+        item.setName(itemName);
+        return item;
+    }
+
+    private static void maybeAddStateFilter(FilterCriteria filter,
+            final DynamoDBQueryExpression<DynamoDBItem<?>> queryExpression) {
+        if (filter.getOperator() != null && filter.getState() != null) {
+            // Convert filter's state to DynamoDBItem in order get suitable string representation for the state
+            final DynamoDBItem<?> filterState = AbstractDynamoDBItem.fromState(filter.getItemName(), filter.getState(),
+                    new Date());
+            queryExpression.setFilterExpression(String.format("%s %s :opstate", DynamoDBItem.ATTRIBUTE_NAME_ITEMSTATE,
+                    operatorAsString(filter.getOperator())));
+
+            filterState.accept(new DynamoDBItemVisitor() {
+
+                @Override
+                public void visit(DynamoDBStringItem dynamoStringItem) {
+                    queryExpression.setExpressionAttributeValues(Collections.singletonMap(":opstate",
+                            new AttributeValue().withS(dynamoStringItem.getState())));
+                }
+
+                @Override
+                public void visit(DynamoDBBigDecimalItem dynamoBigDecimalItem) {
+                    queryExpression.setExpressionAttributeValues(Collections.singletonMap(":opstate",
+                            new AttributeValue().withN(dynamoBigDecimalItem.getState().toPlainString())));
+                }
+            });
+
+        }
+    }
+
+    private static Condition maybeAddTimeFilter(final DynamoDBQueryExpression<DynamoDBItem<?>> queryExpression,
+            final FilterCriteria filter) {
+        final Condition timeCondition = constructTimeCondition(filter);
+        if (timeCondition != null) {
+            queryExpression.setRangeKeyConditions(
+                    Collections.singletonMap(DynamoDBItem.ATTRIBUTE_NAME_TIMEUTC, timeCondition));
+        }
+        return timeCondition;
+    }
+
+    private static Condition constructTimeCondition(FilterCriteria filter) {
+        boolean hasBegin = filter.getBeginDate() != null;
+        boolean hasEnd = filter.getEndDate() != null;
+
+        final Condition timeCondition;
+        if (!hasBegin && !hasEnd) {
+            timeCondition = null;
+        } else if (!hasBegin && hasEnd) {
+            timeCondition = new Condition().withComparisonOperator(ComparisonOperator.LE).withAttributeValueList(
+                    new AttributeValue().withS(AbstractDynamoDBItem.DATEFORMATTER.format(filter.getEndDate())));
+        } else if (hasBegin && !hasEnd) {
+            timeCondition = new Condition().withComparisonOperator(ComparisonOperator.GE).withAttributeValueList(
+                    new AttributeValue().withS(AbstractDynamoDBItem.DATEFORMATTER.format(filter.getBeginDate())));
+        } else {
+            timeCondition = new Condition().withComparisonOperator(ComparisonOperator.BETWEEN).withAttributeValueList(
+                    new AttributeValue().withS(AbstractDynamoDBItem.DATEFORMATTER.format(filter.getBeginDate())),
+                    new AttributeValue().withS(AbstractDynamoDBItem.DATEFORMATTER.format(filter.getEndDate())));
+        }
+        return timeCondition;
+    }
+
+    /**
+     * Convert op to string suitable for dynamodb filter expression
+     *
+     * @param op
+     * @return string representation corresponding to the given the Operator
+     */
+    private static String operatorAsString(Operator op) {
+        switch (op) {
+            case EQ:
+                return "=";
+            case NEQ:
+                return "<>";
+            case LT:
+                return "<";
+            case LTE:
+                return "<=";
+            case GT:
+                return ">";
+            case GTE:
+                return ">=";
+
+            default:
+                throw new IllegalStateException("Unknown operator " + op);
+        }
+    }
+}

--- a/bundles/org.openhab.persistence.dynamodb/src/test/java/org/openhab/persistence/dynamodb/internal/AbstractDynamoDBItemSerializationTest.java
+++ b/bundles/org.openhab.persistence.dynamodb/src/test/java/org/openhab/persistence/dynamodb/internal/AbstractDynamoDBItemSerializationTest.java
@@ -56,22 +56,25 @@ public class AbstractDynamoDBItemSerializationTest {
      * Generic function testing serialization of item state to internal format in DB. In other words, conversion of
      * Item with state to DynamoDBItem
      *
-     * @param state item state
+     * @param state         item state
      * @param expectedState internal format in DB representing the item state
      * @return dynamo db item
      * @throws IOException
      */
-    @SuppressWarnings("unchecked")
     public DynamoDBItem<?> testStateGeneric(State state, Object expectedState) throws IOException {
         DynamoDBItem<?> dbItem = AbstractDynamoDBItem.fromState("item1", state, date);
 
         assertEquals("item1", dbItem.getName());
         assertEquals(date, dbItem.getTime());
+        Object actualState = dbItem.getState();
         if (expectedState instanceof BigDecimal) {
-            assertTrue(DynamoDBBigDecimalItem.loseDigits(((BigDecimal) expectedState))
-                    .compareTo((((DynamoDBItem<BigDecimal>) dbItem).getState())) == 0);
+            BigDecimal expectedRounded = DynamoDBBigDecimalItem.loseDigits(((BigDecimal) expectedState));
+            assertTrue(
+                    String.format("Expected state %s (%s but with some digits lost) did not match actual state %s",
+                            expectedRounded, expectedState, actualState),
+                    expectedRounded.compareTo((BigDecimal) actualState) == 0);
         } else {
-            assertEquals(expectedState, dbItem.getState());
+            assertEquals(expectedState, actualState);
         }
         return dbItem;
     }
@@ -79,8 +82,8 @@ public class AbstractDynamoDBItemSerializationTest {
     /**
      * Test state deserialization, that is DynamoDBItem conversion to HistoricItem
      *
-     * @param dbItem dynamo db item
-     * @param item parameter for DynamoDBItem.asHistoricItem
+     * @param dbItem        dynamo db item
+     * @param item          parameter for DynamoDBItem.asHistoricItem
      * @param expectedState Expected state of the historic item. DecimalTypes are compared with reduced accuracy
      * @return
      * @throws IOException
@@ -94,8 +97,11 @@ public class AbstractDynamoDBItemSerializationTest {
         assertEquals(expectedState.getClass(), historicItem.getState().getClass());
         if (expectedState instanceof DecimalType) {
             // serialization loses accuracy, take this into consideration
-            assertTrue(DynamoDBBigDecimalItem.loseDigits(((DecimalType) expectedState).toBigDecimal())
-                    .compareTo(((DecimalType) historicItem.getState()).toBigDecimal()) == 0);
+            BigDecimal expectedRounded = DynamoDBBigDecimalItem
+                    .loseDigits(((DecimalType) expectedState).toBigDecimal());
+            BigDecimal actual = ((DecimalType) historicItem.getState()).toBigDecimal();
+            assertTrue(String.format("Expected state %s (%s but with some digits lost) did not match actual state %s",
+                    expectedRounded, expectedState, actual), expectedRounded.compareTo(actual) == 0);
         } else if (expectedState instanceof CallType) {
             // CallType has buggy equals, let's compare strings instead
             assertEquals(expectedState.toString(), historicItem.getState().toString());
@@ -181,33 +187,33 @@ public class AbstractDynamoDBItemSerializationTest {
 
     @Test
     public void testDecimalTypeWithNumberItem() throws IOException {
-        DynamoDBItem<?> dbitem = testStateGeneric(new DecimalType(3.2), new BigDecimal(3.2));
-        testAsHistoricGeneric(dbitem, new NumberItem("foo"), new DecimalType(3.2));
+        DynamoDBItem<?> dbitem = testStateGeneric(new DecimalType("3.2"), new BigDecimal("3.2"));
+        testAsHistoricGeneric(dbitem, new NumberItem("foo"), new DecimalType("3.2"));
     }
 
     @Test
     public void testPercentTypeWithColorItem() throws IOException {
-        DynamoDBItem<?> dbitem = testStateGeneric(new PercentType(new BigDecimal(3.2)), new BigDecimal(3.2));
-        testAsHistoricGeneric(dbitem, new ColorItem("foo"), new PercentType(new BigDecimal(3.2)));
+        DynamoDBItem<?> dbitem = testStateGeneric(new PercentType(new BigDecimal("3.2")), new BigDecimal("3.2"));
+        testAsHistoricGeneric(dbitem, new ColorItem("foo"), new PercentType(new BigDecimal("3.2")));
     }
 
     @Test
     public void testPercentTypeWithDimmerItem() throws IOException {
-        DynamoDBItem<?> dbitem = testStateGeneric(new PercentType(new BigDecimal(3.2)), new BigDecimal(3.2));
-        testAsHistoricGeneric(dbitem, new DimmerItem("foo"), new PercentType(new BigDecimal(3.2)));
+        DynamoDBItem<?> dbitem = testStateGeneric(new PercentType(new BigDecimal("3.2")), new BigDecimal("3.2"));
+        testAsHistoricGeneric(dbitem, new DimmerItem("foo"), new PercentType(new BigDecimal("3.2")));
     }
 
     @Test
     public void testPercentTypeWithRollerShutterItem() throws IOException {
-        DynamoDBItem<?> dbitem = testStateGeneric(new PercentType(new BigDecimal(3.2)), new BigDecimal(3.2));
-        testAsHistoricGeneric(dbitem, new RollershutterItem("foo"), new PercentType(new BigDecimal(3.2)));
+        DynamoDBItem<?> dbitem = testStateGeneric(new PercentType(new BigDecimal("3.2")), new BigDecimal("3.2"));
+        testAsHistoricGeneric(dbitem, new RollershutterItem("foo"), new PercentType(new BigDecimal("3.2")));
     }
 
     @Test
     public void testPercentTypeWithNumberItem() throws IOException {
-        DynamoDBItem<?> dbitem = testStateGeneric(new PercentType(new BigDecimal(3.2)), new BigDecimal(3.2));
+        DynamoDBItem<?> dbitem = testStateGeneric(new PercentType(new BigDecimal("3.2")), new BigDecimal("3.2"));
         // note: comes back as DecimalType instead of the original PercentType
-        testAsHistoricGeneric(dbitem, new NumberItem("foo"), new DecimalType(new BigDecimal(3.2)));
+        testAsHistoricGeneric(dbitem, new NumberItem("foo"), new DecimalType(new BigDecimal("3.2")));
     }
 
     @Test

--- a/bundles/org.openhab.persistence.dynamodb/src/test/java/org/openhab/persistence/dynamodb/internal/BaseIntegrationTest.java
+++ b/bundles/org.openhab.persistence.dynamodb/src/test/java/org/openhab/persistence/dynamodb/internal/BaseIntegrationTest.java
@@ -36,7 +36,7 @@ import org.slf4j.LoggerFactory;
 import com.amazonaws.services.dynamodbv2.model.ResourceNotFoundException;
 
 /**
- * 
+ *
  * @author Sami Salonen
  *
  */
@@ -111,6 +111,9 @@ public class BaseIntegrationTest {
         config.put("accessKey", System.getProperty("DYNAMODBTEST_ACCESS"));
         config.put("secretKey", System.getProperty("DYNAMODBTEST_SECRET"));
         config.put("tablePrefix", "dynamodb-integration-tests-");
+
+        // Disable buffering
+        config.put("bufferSize", "0");
 
         for (Entry<String, Object> entry : config.entrySet()) {
             if (entry.getValue() == null) {

--- a/features/karaf/openhab-addons/src/main/feature/feature.xml
+++ b/features/karaf/openhab-addons/src/main/feature/feature.xml
@@ -912,7 +912,7 @@
   </feature>
   
   <feature name="openhab-persistence-dynamodb" description="Amazon DynamoDB Persistence" version="${project.version}">
-	<feature prerequisite="true">wrap</feature>
+    <feature prerequisite="true">wrap</feature>
     <feature>openhab-runtime-base</feature>
     <bundle start-level="80">mvn:org.openhab.persistence/org.openhab.persistence.dynamodb/${project.version}</bundle>
     <bundle dependency="true">wrap:mvn:com.amazonaws/aws-java-sdk-dynamodb/1.11.213$Bundle-Name=AWS%20Java%20SDK%20For%20Amazon%20DynamoDB&amp;Bundle-SymbolicName=aws-java-sdk-dynamodb&amp;Bundle-Version=1.11.213</bundle>

--- a/features/karaf/openhab-addons/src/main/feature/feature.xml
+++ b/features/karaf/openhab-addons/src/main/feature/feature.xml
@@ -912,8 +912,10 @@
   </feature>
   
   <feature name="openhab-persistence-dynamodb" description="Amazon DynamoDB Persistence" version="${project.version}">
+	<feature prerequisite="true">wrap</feature>
     <feature>openhab-runtime-base</feature>
     <bundle start-level="80">mvn:org.openhab.persistence/org.openhab.persistence.dynamodb/${project.version}</bundle>
+    <bundle dependency="true">wrap:mvn:com.amazonaws/aws-java-sdk-dynamodb/1.11.213$Bundle-Name=AWS%20Java%20SDK%20For%20Amazon%20DynamoDB&amp;Bundle-SymbolicName=aws-java-sdk-dynamodb&amp;Bundle-Version=1.11.213</bundle>
     <configfile finalname="${openhab.conf}/services/dynamodb.cfg" override="false">mvn:${project.groupId}/openhab-addons-external/${project.version}/cfg/dynamodb</configfile>
   </feature>
 


### PR DESCRIPTION
In this PR 
- I have taken all the changes from openhab1-addons repo (from `org.openhab.persistence.dynamodb` and `org.openhab.persistence.dynamodb.test` projects)
- removed dependency to google collections (got some build errors with that, and it's not really needed)
- declared dependency to AWS SDK in `pom.xml` and `features.xml`. If I understand correctly, it might enough to declare dependency to `aws-java-sdk-dynamodb` -- this should pick up all the necessary transitive dependencies as well without specifiying them separately in `features.xml` (see `includeTransitiveDependency` in https://svn.apache.org/repos/asf/karaf/site/production/manual/latest/karaf-maven-plugin.html).

`mvn install` of the bundle works without errors. However, `mvn install`  in `openhab2-addons/features/karaf/openhab-addons` outputs the following:

```
<SNIP>
[INFO] Verification of feature openhab-io-webaudio/2.5.0.SNAPSHOT succeeded
[INFO] Unable to determine whether the meta annotation com.amazonaws.annotation.ThreadSafe applied to type com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsyncClient provides bundle annotations as it is not on the project build path. If this annotation does provide bundle annotations then it must be present on the build path in order to be processed
[INFO] Unable to determine whether the meta annotation com.amazonaws.annotation.NotThreadSafe applied to type com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsyncClientBuilder provides bundle annotations as it is not on the project build path. If this annotation does provide bundle annotations then it must be present on the build path in order to be processed
[INFO] Unable to determine whether the meta annotation com.amazonaws.annotation.SdkInternalApi applied to type com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient provides bundle annotations as it is not on the project build path. If this annotation does provide bundle annotations then it must be present on the build path in order to be processed
[INFO] Unable to determine whether the meta annotation com.amazonaws.annotation.GuardedBy applied to type com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBReflector provides bundle annotations as it is not on the project build path. If this annotation does provide bundle annotations then it must be present on the build path in order to be processed
[INFO] Unable to determine whether the meta annotation com.amazonaws.annotation.SdkTestInternalApi applied to type com.amazonaws.services.dynamodbv2.datamodeling.ParallelScanTask provides bundle annotations as it is not on the project build path. If this annotation does provide bundle annotations then it must be present on the build path in order to be processed
[INFO] Unable to determine whether the meta annotation com.fasterxml.jackson.annotation.JsonProperty applied to type com.amazonaws.services.dynamodbv2.datamodeling.S3Link$ID provides bundle annotations as it is not on the project build path. If this annotation does provide bundle annotations then it must be present on the build path in order to be processed
[INFO] Unable to determine whether the meta annotation com.fasterxml.jackson.annotation.JsonIgnore applied to type com.amazonaws.services.dynamodbv2.datamodeling.S3Link$ID provides bundle annotations as it is not on the project build path. If this annotation does provide bundle annotations then it must be present on the build path in order to be processed
[INFO] Unable to determine whether the meta annotation com.amazonaws.annotation.Beta applied to type com.amazonaws.services.dynamodbv2.document.Index provides bundle annotations as it is not on the project build path. If this annotation does provide bundle annotations then it must be present on the build path in order to be processed
[INFO] Unable to determine whether the meta annotation com.amazonaws.annotation.Immutable applied to type com.amazonaws.services.dynamodbv2.xspec.ArrayIndexElement provides bundle annotations as it is not on the project build path. If this annotation does provide bundle annotations then it must be present on the build path in order to be processed
[WARNING] Error resolving artifact org.openhab.persistence:org.openhab.persistence.dynamodb:jar:2.5.0-SNAPSHOT: [Could not find artifact org.openhab.persistence:org.openhab.persistence.dynamodb:jar:2.5.0-SNAPSHOT in openhab-artifactory-snapshot (https://openhab.jfrog.io/openhab/libs-snapshot/)]
java.io.IOException: Error resolving artifact org.openhab.persistence:org.openhab.persistence.dynamodb:jar:2.5.0-SNAPSHOT: [Could not find artifact org.openhab.persistence:org.openhab.persistence.dynamodb:jar:2.5.0-SNAPSHOT in openhab-artifactory-snapshot (https://openhab.jfrog.io/openhab/libs-snapshot/)]
    at org.ops4j.pax.url.mvn.internal.AetherBasedResolver.resolve (AetherBasedResolver.java:720)
    at org.ops4j.pax.url.mvn.internal.AetherBasedResolver.resolve (AetherBasedResolver.java:659)
    at org.ops4j.pax.url.mvn.internal.AetherBasedResolver.resolve (AetherBasedResolver.java:600)
    at org.ops4j.pax.url.mvn.internal.AetherBasedResolver.resolve (AetherBasedResolver.java:567)
    at org.apache.karaf.tooling.utils.ReactorMavenResolver.resolve (ReactorMavenResolver.java:63)
    at org.apache.karaf.features.internal.download.impl.MavenDownloadTask.download (MavenDownloadTask.java:47)
    at org.apache.karaf.features.internal.download.impl.AbstractRetryableDownloadTask.run (AbstractRetryableDownloadTask.java:60)
    at java.util.concurrent.Executors$RunnableAdapter.call (Executors.java:511)
    at java.util.concurrent.FutureTask.run (FutureTask.java:266)
    at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201 (ScheduledThreadPoolExecutor.java:180)
    at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run (ScheduledThreadPoolExecutor.java:293)
    at java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1149)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:624)
    at java.lang.Thread.run (Thread.java:748)
Caused by: shaded.org.eclipse.aether.resolution.ArtifactResolutionException: Error resolving artifact org.openhab.persistence:org.openhab.persistence.dynamodb:jar:2.5.0-SNAPSHOT
    at shaded.org.eclipse.aether.internal.impl.DefaultArtifactResolver.resolve (DefaultArtifactResolver.java:444)
    at shaded.org.eclipse.aether.internal.impl.DefaultArtifactResolver.resolveArtifacts (DefaultArtifactResolver.java:246)
    at shaded.org.eclipse.aether.internal.impl.DefaultArtifactResolver.resolveArtifact (DefaultArtifactResolver.java:223)
    at shaded.org.eclipse.aether.internal.impl.DefaultRepositorySystem.resolveArtifact (DefaultRepositorySystem.java:294)
    at org.ops4j.pax.url.mvn.internal.AetherBasedResolver.resolve (AetherBasedResolver.java:705)
    at org.ops4j.pax.url.mvn.internal.AetherBasedResolver.resolve (AetherBasedResolver.java:659)
    at org.ops4j.pax.url.mvn.internal.AetherBasedResolver.resolve (AetherBasedResolver.java:600)
    at org.ops4j.pax.url.mvn.internal.AetherBasedResolver.resolve (AetherBasedResolver.java:567)
    at org.apache.karaf.tooling.utils.ReactorMavenResolver.resolve (ReactorMavenResolver.java:63)
    at org.apache.karaf.features.internal.download.impl.MavenDownloadTask.download (MavenDownloadTask.java:47)
    at org.apache.karaf.features.internal.download.impl.AbstractRetryableDownloadTask.run (AbstractRetryableDownloadTask.java:60)
    at java.util.concurrent.Executors$RunnableAdapter.call (Executors.java:511)
    at java.util.concurrent.FutureTask.run (FutureTask.java:266)
    at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201 (ScheduledThreadPoolExecutor.java:180)
    at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run (ScheduledThreadPoolExecutor.java:293)
    at java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1149)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:624)
    at java.lang.Thread.run (Thread.java:748)
[WARNING] Feature resolution failed for [openhab-persistence-dynamodb/2.5.0.SNAPSHOT]
Message: org.apache.karaf.features.internal.util.MultiException: Error:
	Error downloading mvn:org.openhab.persistence/org.openhab.persistence.dynamodb/2.5.0-SNAPSHOT
Repositories: {
	file:/home/salski/src/openhab-master/git/openhab2-addons/features/karaf/openhab-addons/target/feature/feature.xml
	mvn:org.apache.karaf.features/framework/4.2.2/xml/features
	mvn:org.apache.karaf.features/standard/4.2.2/xml/features
	mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/2.5.0-SNAPSHOT/xml/features
	mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-tp/2.5.0-SNAPSHOT/xml/features
	mvn:org.ops4j.pax.web/pax-web-features/7.2.5/xml/features
}
Resources: {
	mvn:com.amazonaws/aws-java-sdk-dynamodb/1.11.213
	mvn:org.apache.felix/org.apache.felix.configadmin/1.9.10
	mvn:org.apache.felix/org.apache.felix.coordinator/1.0.2
	mvn:org.apache.felix/org.apache.felix.fileinstall/3.6.4
	mvn:org.apache.karaf.features/org.apache.karaf.features.core/4.2.2
	mvn:org.apache.karaf.features/org.apache.karaf.features.extension/4.2.2
	mvn:org.apache.karaf.jaas/org.apache.karaf.jaas.boot/4.2.2
	mvn:org.apache.karaf.shell/org.apache.karaf.shell.commands/4.2.2
	mvn:org.apache.karaf.shell/org.apache.karaf.shell.core/4.2.2
	mvn:org.apache.karaf.wrapper/org.apache.karaf.wrapper.core/4.2.2
	mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.activation-api-1.1/2.5.0
	mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.jaxb-api-2.2/2.5.0
	mvn:org.fusesource.jansi/jansi/1.17.1
	mvn:org.jline/jline-builtins/3.9.0
	mvn:org.jline/jline-reader/3.9.0
	mvn:org.jline/jline-terminal-jansi/3.9.0
	mvn:org.jline/jline-terminal/3.9.0
	mvn:org.openhab.persistence/org.openhab.persistence.dynamodb/2.5.0-SNAPSHOT
	mvn:org.ops4j.pax.logging/pax-logging-api/1.10.1
	mvn:org.ops4j.pax.logging/pax-logging-log4j2/1.10.1
	mvn:org.ops4j.pax.url/pax-url-aether/2.5.4
	mvn:org.ops4j.pax.url/pax-url-wrap/2.5.4/jar/uber
	wrap:file:/home/salski/.m2/repository/com/amazonaws/aws-java-sdk-dynamodb/1.11.213/aws-java-sdk-dynamodb-1.11.213.jar$Bundle-Name=AWS%20Java%20SDK%20For%20Amazon%20DynamoDB&Bundle-SymbolicName=aws-java-sdk-dynamodb&Bundle-Version=1.11.213
	wrap:mvn:com.amazonaws/aws-java-sdk-dynamodb/1.11.213$Bundle-Name=AWS%20Java%20SDK%20For%20Amazon%20DynamoDB&Bundle-SymbolicName=aws-java-sdk-dynamodb&Bundle-Version=1.11.213
}: openhab-persistence-dynamodb/2.5.0.SNAPSHOT
[WARNING] Error:
	Error downloading mvn:org.openhab.persistence/org.openhab.persistence.dynamodb/2.5.0-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 02:47 min
[INFO] Finished at: 2019-04-28T13:35:25+03:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.karaf.tooling:karaf-maven-plugin:4.2.2:verify (karaf-feature-verification) on project org.openhab.addons.features.karaf.openhab-addons: Feature resolution failed for [openhab-persistence-dynamodb/2.5.0.SNAPSHOT]
[ERROR] Message: org.apache.karaf.features.internal.util.MultiException: Error:
[ERROR] 	Error downloading mvn:org.openhab.persistence/org.openhab.persistence.dynamodb/2.5.0-SNAPSHOT
[ERROR] Repositories: {
[ERROR] 	file:/home/salski/src/openhab-master/git/openhab2-addons/features/karaf/openhab-addons/target/feature/feature.xml
[ERROR] 	mvn:org.apache.karaf.features/framework/4.2.2/xml/features
[ERROR] 	mvn:org.apache.karaf.features/standard/4.2.2/xml/features
[ERROR] 	mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/2.5.0-SNAPSHOT/xml/features
[ERROR] 	mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-tp/2.5.0-SNAPSHOT/xml/features
[ERROR] 	mvn:org.ops4j.pax.web/pax-web-features/7.2.5/xml/features
[ERROR] }
[ERROR] Resources: {
[ERROR] 	mvn:com.amazonaws/aws-java-sdk-dynamodb/1.11.213
[ERROR] 	mvn:org.apache.felix/org.apache.felix.configadmin/1.9.10
[ERROR] 	mvn:org.apache.felix/org.apache.felix.coordinator/1.0.2
[ERROR] 	mvn:org.apache.felix/org.apache.felix.fileinstall/3.6.4
[ERROR] 	mvn:org.apache.karaf.features/org.apache.karaf.features.core/4.2.2
[ERROR] 	mvn:org.apache.karaf.features/org.apache.karaf.features.extension/4.2.2
[ERROR] 	mvn:org.apache.karaf.jaas/org.apache.karaf.jaas.boot/4.2.2
[ERROR] 	mvn:org.apache.karaf.shell/org.apache.karaf.shell.commands/4.2.2
[ERROR] 	mvn:org.apache.karaf.shell/org.apache.karaf.shell.core/4.2.2
[ERROR] 	mvn:org.apache.karaf.wrapper/org.apache.karaf.wrapper.core/4.2.2
[ERROR] 	mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.activation-api-1.1/2.5.0
[ERROR] 	mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.jaxb-api-2.2/2.5.0
[ERROR] 	mvn:org.fusesource.jansi/jansi/1.17.1
[ERROR] 	mvn:org.jline/jline-builtins/3.9.0
[ERROR] 	mvn:org.jline/jline-reader/3.9.0
[ERROR] 	mvn:org.jline/jline-terminal-jansi/3.9.0
[ERROR] 	mvn:org.jline/jline-terminal/3.9.0
[ERROR] 	mvn:org.openhab.persistence/org.openhab.persistence.dynamodb/2.5.0-SNAPSHOT
[ERROR] 	mvn:org.ops4j.pax.logging/pax-logging-api/1.10.1
[ERROR] 	mvn:org.ops4j.pax.logging/pax-logging-log4j2/1.10.1
[ERROR] 	mvn:org.ops4j.pax.url/pax-url-aether/2.5.4
[ERROR] 	mvn:org.ops4j.pax.url/pax-url-wrap/2.5.4/jar/uber
[ERROR] 	wrap:file:/home/salski/.m2/repository/com/amazonaws/aws-java-sdk-dynamodb/1.11.213/aws-java-sdk-dynamodb-1.11.213.jar$Bundle-Name=AWS%20Java%20SDK%20For%20Amazon%20DynamoDB&Bundle-SymbolicName=aws-java-sdk-dynamodb&Bundle-Version=1.11.213
[ERROR] 	wrap:mvn:com.amazonaws/aws-java-sdk-dynamodb/1.11.213$Bundle-Name=AWS%20Java%20SDK%20For%20Amazon%20DynamoDB&Bundle-SymbolicName=aws-java-sdk-dynamodb&Bundle-Version=1.11.213
[ERROR] }
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
```

Any idea why this is?